### PR TITLE
feat: add config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,16 @@ For a full list of available icons see [the SVG directory](./resources/svg).
 
 Via Composer
 
-```bash
+```shell
 $ composer require owenvoke/blade-entypo
+```
+
+## Configuration
+
+Blade Entypo also offers the ability to use features from Blade Icons like default classes, default attributes, etc. If you'd like to configure these, publish the `blade-entypo.php` config file:
+
+```shell
+php artisan vendor:publish --tag=blade-entypo-config
 ```
 
 ## Usage
@@ -48,7 +56,7 @@ And even use inline styles:
 
 If you want to use the raw SVG icons as assets, you can publish them using:
 
-```bash
+```shell
 php artisan vendor:publish --tag=blade-entypo --force
 ```
 

--- a/config/blade-entypo.php
+++ b/config/blade-entypo.php
@@ -1,0 +1,57 @@
+<?php
+
+return [
+
+    /*
+    |-----------------------------------------------------------------
+    | Default Prefix
+    |-----------------------------------------------------------------
+    |
+    | This config option allows you to define a default prefix for
+    | your icons. The dash separator will be applied automatically
+    | to every icon name. It's required and needs to be unique.
+    |
+    */
+
+    'prefix' => 'entypo',
+
+    /*
+    |-----------------------------------------------------------------
+    | Fallback Icon
+    |-----------------------------------------------------------------
+    |
+    | This config option allows you to define a fallback
+    | icon when an icon in this set cannot be found.
+    |
+    */
+
+    'fallback' => '',
+
+    /*
+    |-----------------------------------------------------------------
+    | Default Set Classes
+    |-----------------------------------------------------------------
+    |
+    | This config option allows you to define some classes which
+    | will be applied by default to all icons within this set.
+    |
+    */
+
+    'class' => '',
+
+    /*
+    |-----------------------------------------------------------------
+    | Default Set Attributes
+    |-----------------------------------------------------------------
+    |
+    | This config option allows you to define some attributes which
+    | will be applied by default to all icons within this set.
+    |
+    */
+
+    'attributes' => [
+        // 'width' => 50,
+        // 'height' => 50,
+    ],
+
+];

--- a/src/BladeEntypoServiceProvider.php
+++ b/src/BladeEntypoServiceProvider.php
@@ -5,22 +5,25 @@ declare(strict_types=1);
 namespace OwenVoke\BladeEntypo;
 
 use BladeUI\Icons\Factory;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\ServiceProvider;
 
 final class BladeEntypoServiceProvider extends ServiceProvider
 {
-    private const PATH = 'path';
-
-    private const PREFIX = 'prefix';
-
     public function register(): void
     {
-        $this->callAfterResolving(Factory::class, function (Factory $factory) {
-            $factory->add('entypo', [
-                self::PATH => __DIR__.'/../resources/svg',
-                self::PREFIX => 'entypo',
-            ]);
+        $this->registerConfig();
+
+        $this->callAfterResolving(Factory::class, function (Factory $factory, Container $container) {
+            $config = $container->make('config')->get('blade-entypo', []);
+
+            $factory->add('entypo', array_merge(['path' => __DIR__.'/../resources/svg'], $config));
         });
+    }
+
+    private function registerConfig(): void
+    {
+        $this->mergeConfigFrom(__DIR__ . '/../config/blade-entypo.php', 'blade-entypo');
     }
 
     public function boot(): void
@@ -29,6 +32,10 @@ final class BladeEntypoServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../resources/svg' => public_path('vendor/blade-entypo'),
             ], 'blade-entypo');
+
+            $this->publishes([
+                __DIR__ . '/../config/blade-entypo.php' => $this->app->configPath('blade-entypo.php'),
+            ], 'blade-entypo-config');
         }
     }
 }

--- a/src/BladeEntypoServiceProvider.php
+++ b/src/BladeEntypoServiceProvider.php
@@ -23,7 +23,7 @@ final class BladeEntypoServiceProvider extends ServiceProvider
 
     private function registerConfig(): void
     {
-        $this->mergeConfigFrom(__DIR__ . '/../config/blade-entypo.php', 'blade-entypo');
+        $this->mergeConfigFrom(__DIR__.'/../config/blade-entypo.php', 'blade-entypo');
     }
 
     public function boot(): void
@@ -34,7 +34,7 @@ final class BladeEntypoServiceProvider extends ServiceProvider
             ], 'blade-entypo');
 
             $this->publishes([
-                __DIR__ . '/../config/blade-entypo.php' => $this->app->configPath('blade-entypo.php'),
+                __DIR__.'/../config/blade-entypo.php' => $this->app->configPath('blade-entypo.php'),
             ], 'blade-entypo-config');
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This implements a configuration file as suggested by Dries Vints, allowing the ability to use Blade Icons features like default classes, default attributes, etc.

- [x] I have read the **[CONTRIBUTING](https://github.com/owenvoke/blade-fontawesome/blob/main/.github/CONTRIBUTING.md)** document.
